### PR TITLE
switch to Object.getPrototypeOf

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 'use strict';
 var toString = Object.prototype.toString;
-var hasOwn = Object.prototype.hasOwnProperty;
 
 module.exports = function (x) {
-	var ctor;
-	return toString.call(x) === '[object Object]' && (ctor = x.constructor, hasOwn.call(x, 'constructor') || typeof ctor !== 'function' || ctor instanceof ctor);
+	var prototype;
+	return toString.call(x) === '[object Object]' && (prototype = Object.getPrototypeOf(x), prototype === null || prototype === Object.getPrototypeOf({}));
 };

--- a/test.js
+++ b/test.js
@@ -6,6 +6,11 @@ function Foo(x) {
 	this.x = 1;
 }
 
+function ObjectConstructor() {
+}
+
+ObjectConstructor.prototype.constructor = Object;
+
 test(function (t) {
 	t.assert(fn({}));
 	t.assert(fn({foo: true}));
@@ -26,5 +31,9 @@ test(function (t) {
 	t.assert(!fn(''));
 	t.assert(!fn(0));
 	t.assert(!fn(false));
+	t.assert(!fn(new ObjectConstructor()));
+	var foo = new Foo();
+	foo.constructor = Object;
+	t.assert(!fn(foo));
 	t.end();
 });


### PR DESCRIPTION
Setting the `prototype.constructor` is often considered good practice for constructor functions, but also can be misused to break `is-plain-obj`:

``` js
function ObjectConstructor() {}
ObjectConstructor.prototype.constructor = Object;

isPlainObj(new ObjectConstructor())
//=> true
```

This PR suggest a more reliable test: checking the prototype:

``` js
Object.getPrototypeOf(new ObjectConstructor()) === Object.getPrototypeOf({})
//=> false
```

It is worth noting, however, that neither the current nor the new approach notice setting the internal [[Prototype]] slot:

``` js
function ProtoConstructor() {
  this.__proto__ = Object.prototype;
  // alternatively:
  Object.setPrototypeOf(this, Object.prototype);
}

isPlainObj(new ProtoConstructor())
//=> true
```
