### PR TITLE
Refactor: Use `Object.prototype` directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,8 @@
 'use strict';
+const {prototype, getPrototypeOf} = Object;
+const {toString} = prototype;
+const prototypes = new Set([null, prototype]);
 
-module.exports = value => {
-	if (Object.prototype.toString.call(value) !== '[object Object]') {
-		return false;
-	}
-
-	const prototype = Object.getPrototypeOf(value);
-	return prototype === null || prototype === Object.getPrototypeOf({});
-};
+module.exports = value =>
+	toString.call(value) === '[object Object]' &&
+	prototypes.has(getPrototypeOf(value));

--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
 'use strict';
-const {prototype, getPrototypeOf} = Object;
-const {toString} = prototype;
-const prototypes = new Set([null, prototype]);
 
-module.exports = value =>
-	toString.call(value) === '[object Object]' &&
-	prototypes.has(getPrototypeOf(value));
+module.exports = value => {
+	if (Object.prototype.toString.call(value) !== '[object Object]') {
+		return false;
+	}
+
+	const prototype = Object.getPrototypeOf(value);
+	return prototype === null || prototype === Object.prototype;
+};


### PR DESCRIPTION
use `Object.prototype` directly, instead of `Object.getPrototypeOf({})`