### PR TITLE
Add a test for `Object.create({})`

### DIFF
--- a/test.js
+++ b/test.js
@@ -29,6 +29,7 @@ test('main', t => {
 	t.false(isPlainObject(0));
 	t.false(isPlainObject(false));
 	t.false(isPlainObject(new ObjectConstructor()));
+	t.false(isPlainObject(Object.create({})));
 
 	(function () {
 		t.false(isPlainObject(arguments)); // eslint-disable-line prefer-rest-params


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/is-plain-obj/issues/2

This adds a test for `Object.create({})`.