### PR TITLE
Add one example

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,9 @@ isPlainObject([1, 2, 3]);
 class Unicorn {}
 isPlainObject(new Unicorn());
 //=> false
+
+isPlainObject(Math);
+//=> false
 ```
 */
 export default function isPlainObject<Value>(value: unknown): value is Record<PropertyKey, Value>;

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,9 @@ isPlainObject([1, 2, 3]);
 class Unicorn {}
 isPlainObject(new Unicorn());
 //=> false
+
+isPlainObject(Math);
+//=> false
 ```
 
 ## Related


### PR DESCRIPTION
This adds one example to `readme.md`.

Global namespace objects like `Math`, `JSON`, etc. are very close to plain objects from a prototype standpoint, and can easily create bugs without library like `is-plain-obj`.