### PR TITLE
Upgrade Node version and `devDependencies`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,11 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 14
-          - 12
+          - 22
+          - 18
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/benchmark.js
+++ b/benchmark.js
@@ -27,7 +27,7 @@ const values = [
 	Symbol(''),
 	() => {},
 	// eslint-disable-next-line func-names
-	(function namedFunc() {}),
+	(function namedFunction() {}),
 	null,
 	{},
 	Math,
@@ -36,7 +36,6 @@ const values = [
 	Promise.resolve(),
 	Object.create(null),
 	new Intl.Locale('en'),
-	// eslint-disable-next-line no-new-object
 	new Object({prop: true}),
 	new class Class {}(),
 	[],
@@ -47,7 +46,7 @@ const values = [
 		// eslint-disable-next-line prefer-rest-params
 		return arguments;
 	})(),
-	new Proxy({}, {})
+	new Proxy({}, {}),
 ];
 
 // Warm up V8 optimization.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"type": "module",
 	"exports": "./index.js",
 	"engines": {
-		"node": ">=12"
+		"node": ">=18"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -34,8 +34,8 @@
 		"simple"
 	],
 	"devDependencies": {
-		"ava": "^3.15.0",
-		"tsd": "^0.14.0",
-		"xo": "^0.38.2"
+		"ava": "^6.1.2",
+		"tsd": "^0.31.0",
+		"xo": "^0.58.0"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -16,7 +16,8 @@ test('main', t => {
 	t.true(isPlainObject({constructor: Foo}));
 	t.true(isPlainObject({valueOf: 0}));
 	t.true(isPlainObject(Object.create(null)));
-	t.true(isPlainObject(new Object())); // eslint-disable-line no-new-object
+	// eslint-disable-next-line no-object-constructor
+	t.true(isPlainObject(new Object()));
 	t.true(isPlainObject(runInNewContext('({})')));
 	t.false(isPlainObject(['foo', 'bar']));
 	t.false(isPlainObject(new Foo(1)));


### PR DESCRIPTION
This PR runs the CI on Node 22 and upgrades the development dependencies.

This also drops support for Node 12, 14 and 16. However, this package does not use any Node code, it is pure JavaScript.